### PR TITLE
Update extraction cadence

### DIFF
--- a/etl/pipelines/compute_article_clusters.py
+++ b/etl/pipelines/compute_article_clusters.py
@@ -47,7 +47,7 @@ def compute_article_clusters():
 
 
 # schedules/sensors
-@schedule(cron_schedule="25 */1 * * *", pipeline_name="compute_article_clusters", mode="cloud")
+@schedule(cron_schedule="0 * * * *", pipeline_name="compute_article_clusters", mode="cloud")
 def article_cluster_schedule_12h(context: ScheduleExecutionContext):
     runtime = context.scheduled_execution_time
     if not runtime.tzinfo:
@@ -70,7 +70,7 @@ def article_cluster_schedule_12h(context: ScheduleExecutionContext):
             }}
 
 
-@schedule(cron_schedule="30 */1 * * *", pipeline_name="compute_article_clusters", mode="cloud")
+@schedule(cron_schedule="*/5 * * * *", pipeline_name="compute_article_clusters", mode="cloud")
 def article_cluster_schedule_1d(context: ScheduleExecutionContext):
     runtime = context.scheduled_execution_time
     if not runtime.tzinfo:
@@ -92,7 +92,7 @@ def article_cluster_schedule_1d(context: ScheduleExecutionContext):
             }}
 
 
-@schedule(cron_schedule="35 */1 * * *", pipeline_name="compute_article_clusters", mode="cloud")
+@schedule(cron_schedule="0 */6 * * *", pipeline_name="compute_article_clusters", mode="cloud")
 def article_cluster_schedule_3d(context: ScheduleExecutionContext):
     runtime = context.scheduled_execution_time
     if not runtime.tzinfo:

--- a/etl/pipelines/extract_article_metadata.py
+++ b/etl/pipelines/extract_article_metadata.py
@@ -57,7 +57,7 @@ def extract_article_metadata():
 
 
 # schedules/sensors
-@schedule(cron_schedule="13 */1 * * *", pipeline_name="extract_article_metadata", mode="cloud")
+@schedule(cron_schedule="*/5 * * * *", pipeline_name="extract_article_metadata", mode="cloud")
 def main_schedule(context: ScheduleExecutionContext):
     runtime = context.scheduled_execution_time
     if not runtime.tzinfo:


### PR DESCRIPTION
Updates the cadence for the following schedules:
- extract_article_metadata: every 5 minutes (instead of every hour)
- compute_clusters_1d: every 5 minutes (instead of every hour)
- compute_clusters_3d: every 6 hours (instead of every hour)

The k8s cluster should be able to handle this just fine, but will monitor it for any issues. More frequent extraction runs means each run *should* be smaller, while the clustering will likely be the same cpu/memory load repeatedly anyway.